### PR TITLE
Add async overload

### DIFF
--- a/Tests/RetryTests/RetryTests.swift
+++ b/Tests/RetryTests/RetryTests.swift
@@ -74,4 +74,18 @@ final class RetryTests: XCTestCase {
         XCTAssertEqual(called, 4)
     }
 
+    func test_attempt_async() async throws {
+        func dummyAsyncFunction() async { }
+        var called = 0
+
+        // MUT
+        try await Retry.attempt("", delay: 0, retries: 3) {
+            await dummyAsyncFunction()
+            called += 1
+        }
+
+        // validation
+        XCTAssertEqual(called, 1)
+    }
+
 }


### PR DESCRIPTION
Manually tested:

```
Test Suite 'All tests' started at 2023-10-04 12:33:38.075.
Test Suite 'RetryTests.xctest' started at 2023-10-04 12:33:38.076.
Test Suite 'RetryTests' started at 2023-10-04 12:33:38.076.
Test Case '-[RetryTests.RetryTests test_attempt_async]' started.
Test Case '-[RetryTests.RetryTests test_attempt_async]' passed (0.106 seconds).
Test Case '-[RetryTests.RetryTests test_attempt_immediate_success]' started.
Test Case '-[RetryTests.RetryTests test_attempt_immediate_success]' passed (0.000 seconds).
Test Case '-[RetryTests.RetryTests test_attempt_retryLimitExceeded]' started.
test error
Retrying in 0.0 seconds ...
 (attempt 2)
test error
Retrying in 0.0 seconds ...
 (attempt 3)
test error
Retrying in 0.0 seconds ...
 (attempt 4)
test error
Test Case '-[RetryTests.RetryTests test_attempt_retryLimitExceeded]' passed (0.001 seconds).
Test Case '-[RetryTests.RetryTests test_attempt_success_after_retry]' started.
Error()
Retrying in 0.0 seconds ...
 (attempt 2)
Error()
Retrying in 0.0 seconds ...
 (attempt 3)
Test Case '-[RetryTests.RetryTests test_attempt_success_after_retry]' passed (0.001 seconds).
Test Case '-[RetryTests.RetryTests test_backedOffDelay]' started.
Test Case '-[RetryTests.RetryTests test_backedOffDelay]' passed (0.000 seconds).
Test Suite 'RetryTests' passed at 2023-10-04 12:33:38.187.
	 Executed 5 tests, with 0 failures (0 unexpected) in 0.108 (0.111) seconds
Test Suite 'RetryTests.xctest' passed at 2023-10-04 12:33:38.187.
	 Executed 5 tests, with 0 failures (0 unexpected) in 0.108 (0.111) seconds
Test Suite 'All tests' passed at 2023-10-04 12:33:38.187.
	 Executed 5 tests, with 0 failures (0 unexpected) in 0.108 (0.112) seconds
Program ended with exit code: 0
```